### PR TITLE
Add mediacentral envs to config

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ const config = {
         "companion-eu": "https://companion-cf.lambda-eu.mediastore.dev",
         "attachments-companion": "https://attachments-companion-cf.lambda.mediastore.dev",
         imgResizer: "https://img-resizer.api.mediastore.dev",
+        mediacentral: "https://mcentral.mediastore.click",
       },
       repos: {
         'mpx-ui-admin': {
@@ -170,6 +171,7 @@ const config = {
         "companion-eu": "https://companion-cf.lambda-eu.mediastore.dev",
         "attachments-companion": "https://attachments-companion-cf.lambda.mediastore.dev",
         imgResizer: "https://img-resizer.api.mediastore.dev",
+        mediacentral: "https://mcentral.mediastore.click",
       },
       repos: {
         'mpx-ui-admin': {
@@ -423,6 +425,7 @@ const config = {
         "companion-eu": "https://companion-cf.lambda-eu.mediastore.review",
         "attachments-companion": "https://attachments-companion-cf.lambda.mediastore.review",
         imgResizer: "https://img-resizer.api.mediastore.review",
+        mediacentral: "https://mcentral.mediastore.click",
       },
       repos: {
         'mpx-ui-admin': {
@@ -658,6 +661,7 @@ const config = {
         "companion-eu": "https://companion-cf.lambda-eu.mediastore.app",
         "attachments-companion": "https://attachments-companion-cf.lambda.mediastore.app",
         imgResizer: "https://img-resizer.api.mediastore.app",
+        mediacentral: "https://mediacentral.app",
       },
       repos: {
         'mpx-ui-admin': {
@@ -969,6 +973,7 @@ const config = {
         pigeon: "https://pigeon.api.mediastore.app",
         viscacha: "https://viscacha.api.mediastore.app",
         imgResizer: "https://img-resizer.api.mediastore.app",
+        mediacentral: "https://mediacentral.app",
       },
       repos: {
         'mpx-ui-gcui': {


### PR DESCRIPTION
This PR adds media central env hostnames to import assets from media store to media central. 
See [#3196](https://github.com/mediafellows/mfx-ui-admin-v3/pull/3197)