### PR TITLE
Update CSP

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const {existsSync} = require('fs')
 // Documented at https://developer.mozilla.org/de/docs/Web/HTTP/Headers/Content-Security-Policy
 const defaultCSP = {
   'default-src': [
-    "'none'"
+    "'self'"
   ],
   'script-src': [
     "'self'",

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ const defaultCSP = {
   ],
   'media-src': [
     "'self'",
+    "data:",
     "blob:",
     "*.{{base_domain}}",
     "*.amazonaws.com",

--- a/index.mock.js
+++ b/index.mock.js
@@ -2,7 +2,7 @@ const {merge, trim, reduce} = require('lodash')
 const {execSync} = require('child_process')
 
 const defaultCSP = {
-  'default-src': ["'none'"],
+  'default-src': ["'self'"],
   'child-src': ["blob:"],
   'script-src': [
     "'self' 'unsafe-inline' 'unsafe-eval'",

--- a/index.mock.js
+++ b/index.mock.js
@@ -45,7 +45,7 @@ const defaultCSP = {
     "licensing.theoplayer.com",
   ],
   'media-src': [
-    "'self' blob:",
+    "'self' data: blob:",
     "*.{{base_domain}}",
     "*.s3-accelerate.amazonaws.com *.s3.amazonaws.com",
   ],


### PR DESCRIPTION
**Change default-src to self**
This is needed for icons in FF (already hardcoded in many FE projects for a long time). Without this Firefox does not allow loading symbols from an svg file using `href`

**Add data: to media-src**
This is needed for new theo player. Player instance is initialized without source and current version is trying to load a base64 mp4 dummy source. Without this player `autoplay` does not work properly